### PR TITLE
feat: Add testbed for rendering node & pod blocks

### DIFF
--- a/src/components/DevelopmentOnlyAlert/index.tsx
+++ b/src/components/DevelopmentOnlyAlert/index.tsx
@@ -17,7 +17,7 @@ export default ({ id, data, onChangeData, ...otherProps }: Props) => {
           <Space direction="vertical">
             <Row gutter={[10, 10]} style={{ textAlign: 'right' }}>
               {data.showGrids !== undefined && (
-                <Col span={12}>
+                <Col span={8}>
                   <label htmlFor="s1">격자 보기 </label>
                   <Switch
                     id="s1"
@@ -30,7 +30,7 @@ export default ({ id, data, onChangeData, ...otherProps }: Props) => {
                 </Col>
               )}
               {data.showPoints !== undefined && (
-                <Col span={12}>
+                <Col span={8}>
                   <label htmlFor="s2">좌표 보기 </label>
                   <Switch
                     id="s2"
@@ -38,6 +38,19 @@ export default ({ id, data, onChangeData, ...otherProps }: Props) => {
                     checked={data.showPoints}
                     onChange={(showPoints) =>
                       onChangeData({ ...data, showPoints })
+                    }
+                  />
+                </Col>
+              )}
+              {data.showBlocks !== undefined && (
+                <Col span={8}>
+                  <label htmlFor="s3">샘플 블럭 보기 </label>
+                  <Switch
+                    id="s3"
+                    size="small"
+                    checked={data.showBlocks}
+                    onChange={(showBlocks) =>
+                      onChangeData({ ...data, showBlocks })
                     }
                   />
                 </Col>

--- a/src/components/UncloudyGraph/index.tsx
+++ b/src/components/UncloudyGraph/index.tsx
@@ -8,8 +8,14 @@ import type { Props } from './types';
 
 type View = 'numPods' | 'CPUUsage' | 'memoryUsage' | 'nodeId';
 
+const sampleChunks = [
+  [1, 2, 3],
+  [4, 5, 6],
+];
+
 export default ({
   id,
+  panelMode,
   clusters,
   nodes,
   deployments,
@@ -19,22 +25,28 @@ export default ({
 }: Props) => {
   const [isDevMode] = useState(process.env.NODE_ENV === 'development');
 
-  const [resourceRef, updateResourcePainter] = usePainter('box');
+  const [sampleRef, updateSamplePainter] = usePainter('box');
+  const [nodeRef, updateNodePainter] = usePainter('node');
+  const [podRef, updatePodPainter] = usePainter('pod');
   const [pointRef, _p, setPointRefVisible] = usePainter('point');
   const [gridRef, _g, setGridRefVisible] = usePainter('grid');
-  const [debugBoxRef, _d, setDebugBoxRefVisible] = usePainter('grid');
 
   useEffect(() => {
-    const chunks = [
-      [1, 2, 3],
-      [4, 5, 6],
-    ];
-    updateResourcePainter(chunks);
-  }, []);
+    if (panelMode === 'admin') {
+      updateNodePainter(sampleChunks);
+      updatePodPainter([]);
+    } else {
+      updateNodePainter([]);
+      updatePodPainter(sampleChunks);
+    }
+  }, [panelMode]);
 
   useEffect(() => {
-    const { showBlocks, showGrids, showPoints } = options;
-    showBlocks !== undefined && setDebugBoxRefVisible(showBlocks);
+    updateSamplePainter(!!options.showBlocks ? sampleChunks : []);
+  }, [options.showBlocks]);
+
+  useEffect(() => {
+    const { showGrids, showPoints } = options;
     showPoints !== undefined && setPointRefVisible(showPoints);
     showGrids !== undefined && setGridRefVisible(showGrids);
   }, [options]);
@@ -62,12 +74,24 @@ export default ({
         </>
       )}
       <canvas
-        ref={resourceRef}
-        id="resources"
+        ref={sampleRef}
+        id="samples"
         style={{
-          marginBottom: resourceRef.current
-            ? -resourceRef.current.clientHeight
-            : 0,
+          marginBottom: nodeRef.current ? -nodeRef.current.clientHeight : 0,
+        }}
+      />
+      <canvas
+        ref={nodeRef}
+        id="nodes"
+        style={{
+          marginBottom: nodeRef.current ? -nodeRef.current.clientHeight : 0,
+        }}
+      />
+      <canvas
+        ref={podRef}
+        id="pods"
+        style={{
+          marginBottom: podRef.current ? -podRef.current.clientHeight : 0,
         }}
       />
 

--- a/src/hooks/usePainter.ts
+++ b/src/hooks/usePainter.ts
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { renderGrids, renderLegend, renderObjects, renderPoints } from '~utils/painter';
 
 export default (
-  drawingType: 'grid' | 'point' | 'legend' | 'box' | 'grass'
+  drawingType: 'grid' | 'point' | 'legend' | 'box' | 'grass' | 'node' | 'pod'
 ): [
   React.RefObject<HTMLCanvasElement>,
   React.Dispatch<React.SetStateAction<number[][]>>,

--- a/src/utils/painter.ts
+++ b/src/utils/painter.ts
@@ -50,6 +50,64 @@ export const paintCube: Painter.PaintObject = (ctx, x, y, dx, dy, h) => [
   },
 ];
 
+/**
+ * 노드 블럭을 렌더링합니다.
+ * @author 김민정
+ * @param ctx: 캔버스 포인터
+ * @param x: 노드 블럭의 x 시작점
+ * @param y: 노드 블럭의 y 시작점
+ * @param dx: 노드 블럭의 x 크기
+ * @param dy: 노드 블럭의 y 크기
+ * @param h: 노드 블럭의 높이
+ * @returns () => void
+ */
+export const paintNode: Painter.PaintObject = (ctx, x, y, dx, dy, h) => [
+  () => {
+    ctx.save();
+
+    ctx.fillStyle = 'green';
+    ctx.beginPath();
+    ctx.moveTo(75, 50);
+    ctx.lineTo(100, 75);
+    ctx.lineTo(125, 50);
+    ctx.lineTo(100, 25);
+    ctx.fill();
+
+    ctx.fillStyle = 'brown';
+    ctx.beginPath();
+    ctx.moveTo(125, 50);
+    ctx.lineTo(125, 75);
+    ctx.lineTo(100, 100);
+    ctx.lineTo(75, 75);
+    ctx.lineTo(75, 50);
+    ctx.lineTo(100, 75);
+    ctx.fill();
+
+    ctx.restore();
+  },
+];
+
+/**
+ * 파드 블럭을 렌더링합니다.
+ * @author 백명상
+ * @param ctx: 캔버스 포인터
+ * @param x: 파드 블럭의 x 시작점
+ * @param y: 파드 블럭의 y 시작점
+ * @param dx: 파드 블럭의 x 크기
+ * @param dy: 파드 블럭의 y 크기
+ * @param h: 파드 블럭의 높이
+ * @returns () => void
+ */
+export const paintPod: Painter.PaintObject = (ctx, x, y, dx, dy, h) => [
+  () => {
+    ctx.save();
+
+    // TODO 코드 작성
+
+    ctx.restore();
+  },
+];
+
 export const paintPoint: Painter.PaintObject = (ctx, x, y, dx, dy, h) => [
   () => {
     ctx.save();
@@ -314,13 +372,28 @@ export const renderObjects = (
   ctx: CanvasRenderingContext2D,
   currentRef: HTMLCanvasElement,
   dataChunks: number[][],
-  paintingType: 'box' | 'grass'
+  paintingType: 'box' | 'grass' | 'node' | 'pod'
 ) => {
   const stackPaintingObject: any[] = [];
-  const paintObject = paintingType === 'box' ? paintCube : paintGrasses;
   const x0 = currentRef.width / 2 + 6 * DX;
   const y0 = currentRef.height / 4 + 6 * DY;
   const height = paintingType === 'box' ? 5 : 15;
+
+  let paintObject: Painter.PaintObject;
+  switch (paintingType) {
+    case 'box':
+      paintObject = paintCube;
+      break;
+    case 'grass':
+      paintObject = paintGrasses;
+      break;
+    case 'node':
+      paintObject = paintNode;
+      break;
+    case 'pod':
+      paintObject = paintPod;
+      break;
+  }
 
   ctx.lineJoin = 'round';
   ctx.fillStyle = 'transparent';
@@ -344,7 +417,7 @@ export const renderObjects = (
   const render = () => {
     ctx.clearRect(0, 0, currentRef.width, currentRef.height);
     ctx.fillRect(0, 0, currentRef.width, currentRef.height);
-    stackPaintingObject.forEach((paintObject) => paintObject());
+    stackPaintingObject.forEach((paint) => paint());
 
     paintingType === 'grass' && requestAnimationFrame(render);
   };


### PR DESCRIPTION
다음 Pull Request에는 다음 내용들이 포함되어 있습니다:

- [feat: 노드 및 파드 블럭 렌더링 구현을 위한 테스트베드 옵션 추가 (샘플 블럭 보기 기능)](https://github.com/team-grass-farm/uncloudy-grapher/commit/a0d1c4cc325ad0b25de3a01ff20c945208a13693)
