### PR TITLE
fix: Remove duplicated return ret

### DIFF
--- a/src/utils/positioner.ts
+++ b/src/utils/positioner.ts
@@ -82,8 +82,6 @@ export const getGridPositions: Positioner.GetGridPositions = (
           }
         });
         ret.push(...bucket.reverse()); //우상단 ~ 좌하단 배치
-
-        return ret;
       });
       break;
   }


### PR DESCRIPTION
다음 Pull Request는 positioner.ts 모듈 내 중복된 `return ret;` 항목으로 인한 tslint 오류를 잡아내기 위한 fix 커밋이며, 즉각 develop에 반영합니다.