### PR TITLE
Refactor/positioner

### DIFF
--- a/@types/global/index.d.ts
+++ b/@types/global/index.d.ts
@@ -1,7 +1,6 @@
 declare type PointType = 'pod' | 'node' | 'point';
 declare type LineType = 'grid';
 declare type GroupType = 'deployment' | 'namespace' | 'cluster' | 'node';
-declare type Layer = 'group2' | 'group1' | 'block';
 
 declare interface Matrix {
   row: number;
@@ -30,4 +29,20 @@ declare interface GroupPosition {
   end: PointPosition;
   zIndex: number;
   type: GroupType;
+}
+
+declare interface BlockPositions {
+  viewType: 'flat' | 'normal';
+  dx: number;
+  dy: number;
+  dz?: number;
+  data: PointPosition[];
+}
+
+declare interface GroupPositions {
+  viewType: 'flat' | 'normal';
+  dx: number;
+  dy: number;
+  dz?: number;
+  data: GroupPosition[];
 }

--- a/@types/global/index.d.ts
+++ b/@types/global/index.d.ts
@@ -1,3 +1,5 @@
+declare type Dimensions = Record<'width' | 'height', number>;
+
 declare type PointType = 'pod' | 'node' | 'point';
 declare type LineType = 'grid';
 declare type GroupType = 'deployment' | 'namespace' | 'cluster' | 'node';

--- a/@types/painter/index.d.ts
+++ b/@types/painter/index.d.ts
@@ -68,6 +68,11 @@ declare namespace Painter {
     animated: boolean
   ) => void;
 
+  type ClearRendered = (
+    ctx: CanvasRenderingContext2D,
+    dimensions: Dimensions
+  ) => void;
+
   type Render<
     T extends
       | PointPosition[]

--- a/@types/painter/index.d.ts
+++ b/@types/painter/index.d.ts
@@ -1,5 +1,5 @@
 declare namespace Painter {
-  type Layer = 'blocks' | 'groups1' | 'groups2' | 'main';
+  type Layer = 'blocks' | 'groups1' | 'groups2' | 'base';
   type Paint = (plot: Positioner.Plot) => void;
   type Option =
     | {
@@ -60,13 +60,25 @@ declare namespace Painter {
     ? GroupPosition
     : PointPosition;
 
+  type BaseRender = (
+    ctx: CanvasRenderingContext2D,
+    dimensions: Dimensions,
+    stackPaintings: (() => void)[],
+    clearCanvas: boolean,
+    animated: boolean
+  ) => void;
+
   type Render<
-    T extends PointPosition[] | LinePosition[] | BlockPositions | GroupPositions
+    T extends
+      | PointPosition[]
+      | LinePosition[]
+      | BlockPositions
+      | GroupPositions
+      | null
   > = (
     ctx: CanvasRenderingContext2D,
-    currentRef: HTMLCanvasElement,
+    dimensions: Dimensions,
     positions: T,
-    visible: boolean,
-    selectedPosition?: SelectedPosition<T> | null
+    isBaseCanvas?: boolean
   ) => void;
 }

--- a/@types/painter/index.d.ts
+++ b/@types/painter/index.d.ts
@@ -1,4 +1,6 @@
 declare namespace Painter {
+  type Layer = 'blocks' | 'groups1' | 'groups2' | 'main';
+  type Paint = (plot: Positioner.Plot) => void;
   type Option =
     | {
         text: string;
@@ -15,6 +17,16 @@ declare namespace Painter {
         color?: never;
         selected: boolean;
       };
+
+  interface RefMap extends Record<Layer, RefObject<HTMLCanvasElement>> {
+    grid?: RefObject<HTMLCanvasElement>;
+    points?: RefObject<HTMLCanvasElement>;
+    event: RefObject<HTMLCanvasElement>;
+  }
+  interface FlagMap extends Record<Layer, boolean> {
+    grid?: boolean;
+    points?: boolean;
+  }
 
   type PaintObject = (
     ctx: CanvasRenderingContext2D,
@@ -44,12 +56,17 @@ declare namespace Painter {
     option?: Option
   ) => () => void;
 
-  type Render<T = PointPosition | LinePosition | GroupPosition> = (
+  type SelectedPosition<T> = T extends GroupPositions
+    ? GroupPosition
+    : PointPosition;
+
+  type Render<
+    T extends PointPosition[] | LinePosition[] | BlockPositions | GroupPositions
+  > = (
     ctx: CanvasRenderingContext2D,
     currentRef: HTMLCanvasElement,
-    positions: T[],
+    positions: T,
     visible: boolean,
-    level?: 1 | 2 | 3,
-    selectedPosition?: T | null
+    selectedPosition?: SelectedPosition<T> | null
   ) => void;
 }

--- a/@types/positioner/index.d.ts
+++ b/@types/positioner/index.d.ts
@@ -1,5 +1,5 @@
 declare namespace Positioner {
-  type Pose = (resourceMap: Positioner.ResourceMap) => void;
+  type Pose = (resourceMap: Positioner.ResourceMap, level: 1 | 2 | 3) => void;
 
   type AdminResourceMap =
     | {

--- a/@types/positioner/index.d.ts
+++ b/@types/positioner/index.d.ts
@@ -1,5 +1,4 @@
 declare namespace Positioner {
-  type Dimensions = Record<'width' | 'height', number>;
   type Pose = (resourceMap: Positioner.ResourceMap) => void;
 
   type AdminResourceMap =

--- a/src/components/Grass/index.tsx
+++ b/src/components/Grass/index.tsx
@@ -45,7 +45,6 @@ export default ({ ...otherProps }: Props) => {
           tall = Math.min(x / 2, maxTall),
           size = Math.min(x / 10, maxSize);
         x += speed;
-        // console.log('x: ', x);
 
         ctx.save();
         // ctx.strokeWidth = 10;

--- a/src/components/UncloudyGraph/index.tsx
+++ b/src/components/UncloudyGraph/index.tsx
@@ -22,17 +22,16 @@ export default ({
     setDimensions,
     setVisible,
   ] = usePainter();
-  const [dimensions, plot, pose, setLevelOnPositioner] = usePositioner(
-    refMap.base
-  );
+  const [dimensions, plot, pose] = usePositioner(refMap.base);
 
   useEffect(() => {
+    if (!!!options.level) return;
     if (type === 'admin') {
       const { pods, clusters, nodes } = data;
-      pose({ type, pods, nodes, clusters });
+      pose({ type, pods, nodes, clusters }, options.level);
     } else {
       const { pods, deployments, namespaces } = data;
-      pose({ type, pods, deployments, namespaces });
+      pose({ type, pods, deployments, namespaces }, options.level);
     }
   }, [type, options.level, data]);
 
@@ -52,7 +51,6 @@ export default ({
     });
     if (level !== undefined) {
       setLevelOnPainter(level);
-      setLevelOnPositioner(level);
     }
   }, [options]);
 

--- a/src/components/UncloudyGraph/index.tsx
+++ b/src/components/UncloudyGraph/index.tsx
@@ -1,6 +1,7 @@
 import { Col, Row, Select } from 'antd';
 import React, { useEffect } from 'react';
 import { usePainter, usePositioner } from '~hooks';
+import { report } from '~utils/logger';
 
 import { MainBlock } from './styles';
 
@@ -89,7 +90,9 @@ export default ({
           <Col span={6}>
             <Select
               mode="multiple"
-              onChange={(value) => console.log('value: ', value)}
+              onChange={(value) =>
+                report.log('UncloudyGraph', ['viewType value: ', value])
+              }
               style={{ width: '100%' }}
               placeholder="보기 설정"
               maxTagCount="responsive"

--- a/src/components/UncloudyGraph/index.tsx
+++ b/src/components/UncloudyGraph/index.tsx
@@ -1,25 +1,40 @@
 import { Col, Row, Select } from 'antd';
-import React, { useEffect, useLayoutEffect } from 'react';
-import { usePainter } from '~hooks';
+import React, { useEffect } from 'react';
+import { usePainter, usePositioner } from '~hooks';
 
 import { MainBlock } from './styles';
 
 import type { Props } from './types';
 
 export default ({ id, panelMode, data, options, ...otherProps }: Props) => {
-  const [refMap, level, update, setLevel, setVisible, selectedPoint] =
+  const [refMap, level, paint, setLevel, setVisible, selectedPoint] =
     usePainter(options.level ?? 2);
+  const [dimensions, plot, pose] = usePositioner(
+    options.level ?? 2,
+    refMap.main
+  );
 
-  useEffect(() => update(panelMode), [panelMode, level, data]);
+  useEffect(() => {
+    if (panelMode === 'admin') {
+      const { pods, clusters, nodes } = data;
+      pose({ type: panelMode, pods, nodes, clusters });
+    } else {
+      const { pods, deployments, namespaces } = data;
+      pose({ type: panelMode, pods, deployments, namespaces });
+    }
+  }, [panelMode, level, data]);
+
+  useEffect(() => (plot ? paint(plot) : undefined), [plot]);
 
   useEffect(() => {
     const { showGrids, showPoints, showBlocks, level } = options;
     setVisible({
       grid: showGrids ?? true,
-      point: showPoints ?? true,
-      block: showBlocks ?? true,
-      group1: true,
-      group2: true,
+      points: showPoints ?? true,
+      main: true,
+      blocks: showBlocks ?? true,
+      groups1: true,
+      groups2: true,
     });
     level !== undefined && setLevel(level);
   }, [options]);

--- a/src/components/UncloudyGraph/index.tsx
+++ b/src/components/UncloudyGraph/index.tsx
@@ -6,37 +6,53 @@ import { MainBlock } from './styles';
 
 import type { Props } from './types';
 
-export default ({ id, panelMode, data, options, ...otherProps }: Props) => {
-  const [refMap, level, paint, setLevel, setVisible, selectedPoint] =
-    usePainter(options.level ?? 2);
-  const [dimensions, plot, pose] = usePositioner(
-    options.level ?? 2,
-    refMap.main
+export default ({
+  id,
+  panelMode: type,
+  data,
+  options,
+  ...otherProps
+}: Props) => {
+  const [
+    refMap,
+    selectedPoint,
+    paint,
+    setLevelOnPainter,
+    setDimensions,
+    setVisible,
+  ] = usePainter();
+  const [dimensions, plot, pose, setLevelOnPositioner] = usePositioner(
+    refMap.base
   );
 
   useEffect(() => {
-    if (panelMode === 'admin') {
+    if (type === 'admin') {
       const { pods, clusters, nodes } = data;
-      pose({ type: panelMode, pods, nodes, clusters });
+      pose({ type, pods, nodes, clusters });
     } else {
       const { pods, deployments, namespaces } = data;
-      pose({ type: panelMode, pods, deployments, namespaces });
+      pose({ type, pods, deployments, namespaces });
     }
-  }, [panelMode, level, data]);
+  }, [type, options.level, data]);
 
   useEffect(() => (plot ? paint(plot) : undefined), [plot]);
+
+  useEffect(() => setDimensions(dimensions), [dimensions]);
 
   useEffect(() => {
     const { showGrids, showPoints, showBlocks, level } = options;
     setVisible({
       grid: showGrids ?? true,
       points: showPoints ?? true,
-      main: true,
+      base: true,
       blocks: showBlocks ?? true,
       groups1: true,
       groups2: true,
     });
-    level !== undefined && setLevel(level);
+    if (level !== undefined) {
+      setLevelOnPainter(level);
+      setLevelOnPositioner(level);
+    }
   }, [options]);
 
   return (

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useFetcher } from './useFetcher';
 export { default as usePainter } from './usePainter';
 export { default as usePainterEvent } from './usePainterEvent';
+export { default as usePositioner } from './usePositioner';

--- a/src/hooks/useFetcher.ts
+++ b/src/hooks/useFetcher.ts
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { SAMPLE_NODES, SAMPLE_PODS } from '~constants';
 
 export default (

--- a/src/hooks/usePainter.ts
+++ b/src/hooks/usePainter.ts
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from 'react';
 import { usePainterEvent } from '~hooks';
+import { report } from '~utils/logger';
 import { renderBlocks, renderGrids, renderPoints } from '~utils/painter';
 import { getGridPositions, getPointPositions } from '~utils/positioner';
 
@@ -56,6 +57,7 @@ export default (): [
 
   useEffect(() => {
     if (refMap.blocks.current === null) return;
+    report.log('usePainter', ['dimensions changed:', dimensions]);
     Object.values(refMap).forEach((ref) => {
       if (ref.current) {
         ref.current.width = ref.current.clientWidth;
@@ -66,7 +68,7 @@ export default (): [
 
   const paint = useCallback(
     (plot: Positioner.Plot) => {
-      console.debug('[usePainter] plot: ', plot);
+      report.log('usePainter', ['plot: ', plot]);
       (
         Object.entries(refMap) as [
           keyof Painter.RefMap,

--- a/src/hooks/usePainter.ts
+++ b/src/hooks/usePainter.ts
@@ -1,37 +1,22 @@
 import React, { RefObject, useCallback, useEffect, useRef, useState } from 'react';
 import { usePainterEvent } from '~hooks';
 import { renderGrids, renderObjects, renderPoints } from '~utils/painter';
-import {
-    getAdminViewPositions, getDeveloperViewPositions, getGridPositions, getPointPositions
-} from '~utils/positioner';
-
-type Layer = 'block' | 'group1' | 'group2';
-type Paint = (panelMode: 'dev' | 'admin') => void;
+import { getGridPositions, getPointPositions } from '~utils/positioner';
 
 // NOTE grid & point is skippable because these are just for debugging.
-interface RefMap extends Record<Layer, RefObject<HTMLCanvasElement>> {
-  grid?: RefObject<HTMLCanvasElement>;
-  point?: RefObject<HTMLCanvasElement>;
-  event: RefObject<HTMLCanvasElement>;
-}
-interface FlagMap extends Record<Layer, boolean> {
-  grid?: boolean;
-  point?: boolean;
-}
-
 export default (
   _level: 1 | 2 | 3
 ): [
-  RefMap,
+  Painter.RefMap,
   1 | 2 | 3,
-  Paint,
+  Painter.Paint,
   React.Dispatch<1 | 2 | 3>,
-  React.Dispatch<React.SetStateAction<FlagMap>>,
+  React.Dispatch<React.SetStateAction<Painter.FlagMap>>,
   PointPosition | null
 ] => {
-  const [data, setData] = useState<Positioner.Plot | null>(null);
+  const [plot, setPlot] = useState<Positioner.Plot | null>(null);
   const [isDevMode] = useState(process.env.NODE_ENV === 'development');
-  const [paused, setPaused] = useState<boolean>(true);
+  const [forcePaint, setForcePaint] = useState<boolean>(true);
   const [level, setLevel] = useState<1 | 2 | 3>(_level);
   const [dimensions, setDimensions] = useState<
     Record<'width' | 'height', number>
@@ -41,171 +26,132 @@ export default (
     dimensions,
     level
   );
-  const refMap: RefMap = {
+  const refMap: Painter.RefMap = {
     ...(isDevMode && {
       grid: useRef<HTMLCanvasElement>(null),
-      point: useRef<HTMLCanvasElement>(null),
+      points: useRef<HTMLCanvasElement>(null),
     }),
-    group2: useRef<HTMLCanvasElement>(null),
-    group1: useRef<HTMLCanvasElement>(null),
-    block: useRef<HTMLCanvasElement>(null),
+    main: useRef<HTMLCanvasElement>(null),
+    groups2: useRef<HTMLCanvasElement>(null),
+    groups1: useRef<HTMLCanvasElement>(null),
+    blocks: useRef<HTMLCanvasElement>(null),
     event: eventRef,
   };
-  const [visible, setVisible] = useState<FlagMap>({
+  const [visible, setVisible] = useState<Painter.FlagMap>({
     ...(isDevMode && {
       grid: true,
       point: true,
     }),
-    group2: true,
-    group1: true,
-    block: true,
+    main: true,
+    groups2: true,
+    groups1: true,
+    blocks: true,
   });
 
   useEffect(() => {
-    const pauser = () => setPaused(true);
-    window.addEventListener('resize', pauser);
-    return () => window.removeEventListener('resize', pauser);
-  }, []);
-
-  useEffect(() => {
-    let handler: NodeJS.Timeout | undefined;
-    if (paused) {
-      // handler = setTimeout(() => {
-      if (refMap.block.current === null) return;
-      console.log('executed handleResize()');
-      setDimensions({
-        width: refMap.block.current.clientWidth,
-        height: refMap.block.current.clientHeight,
-      });
-
-      Object.values(refMap).forEach((ref) => {
-        if (ref.current) {
-          ref.current.width = ref.current.clientWidth;
-          ref.current.height = ref.current.clientHeight;
-        }
-      });
-      setPaused(false);
-      // }, 0);
-    } else {
-      handler = undefined;
-    }
-    return () => {
-      clearTimeout(handler);
-      console.debug('[usePainter] timeout cleared: ', paused);
-    };
-  }, [paused]);
-
-  useEffect(() => {
-    (
-      Object.entries(refMap) as [keyof RefMap, RefObject<HTMLCanvasElement>][]
-    ).map(([refName, ref]) => {
-      const ctx = ref.current && ref.current.getContext('2d');
-      if (ctx === null || ref.current === null) return;
-      switch (refName) {
-        case 'grid':
-          renderGrids(
-            ctx,
-            ref.current,
-            getGridPositions(dimensions.width, dimensions.height, level ?? 2),
-            visible.grid ?? false
-          );
-          break;
-        case 'point':
-          renderPoints(
-            ctx,
-            ref.current,
-            getPointPositions(dimensions.width, dimensions.height, level ?? 2),
-            visible.point ?? false
-          );
-          break;
-        case 'block':
-          data &&
-            renderObjects(
-              ctx,
-              ref.current,
-              // data.block,
-              [],
-              visible.block ?? false,
-              level
-            );
-          break;
-        case 'group1':
-          break;
-        case 'group2':
-          // data &&
-          //   data.group2 &&
-          //   renderGroups(ctx, ref.current, data.group2, null, true, level);
-          break;
-        default:
-          break;
+    if (forcePaint || refMap.blocks.current === null) return;
+    setDimensions({
+      width: refMap.blocks.current.clientWidth,
+      height: refMap.blocks.current.clientHeight,
+    });
+    Object.values(refMap).forEach((ref) => {
+      if (ref.current) {
+        ref.current.width = ref.current.clientWidth;
+        ref.current.height = ref.current.clientHeight;
       }
     });
-    setLevelOnEvent(level);
-  }, [data, dimensions, level, visible]);
+  }, [forcePaint]);
+
+  const paint = useCallback(
+    (plot: Positioner.Plot) => {
+      console.debug('[usePainter] plot: ', plot);
+      (
+        Object.entries(refMap) as [
+          keyof Painter.RefMap,
+          RefObject<HTMLCanvasElement>
+        ][]
+      ).map(([refName, ref]) => {
+        const ctx = ref.current && ref.current.getContext('2d');
+        if (ctx === null || ref.current === null) return;
+        switch (refName) {
+          case 'grid':
+            renderGrids(
+              ctx,
+              ref.current,
+              getGridPositions(dimensions.width, dimensions.height, level ?? 2),
+              visible.grid ?? false
+            );
+            break;
+          case 'points':
+            renderPoints(
+              ctx,
+              ref.current,
+              getPointPositions(
+                dimensions.width,
+                dimensions.height,
+                level ?? 2
+              ),
+              visible.points ?? false
+            );
+            break;
+          case 'blocks':
+            plot &&
+              renderObjects(
+                ctx,
+                ref.current,
+                plot.blocks,
+                visible.blocks ?? false
+              );
+            break;
+          case 'groups1':
+            break;
+          case 'groups2':
+            // data &&
+            //   data.group2 &&
+            //   renderGroups(ctx, ref.current, data.group2, null, true, level);
+            break;
+          default:
+            break;
+        }
+      });
+      setLevelOnEvent(level);
+    },
+    [dimensions, level, visible]
+  );
 
   useEffect(() => {
     (
-      Object.entries(refMap) as [keyof RefMap, RefObject<HTMLCanvasElement>][]
+      Object.entries(refMap) as [
+        keyof Painter.RefMap,
+        RefObject<HTMLCanvasElement>
+      ][]
     ).map(([refName, ref]) => {
       const ctx = ref.current && ref.current.getContext('2d');
       if (ctx === null || ref.current === null) return;
       switch (refName) {
-        case 'point':
+        case 'points':
           renderPoints(
             ctx,
             ref.current,
             getPointPositions(dimensions.width, dimensions.height, level ?? 2),
-            visible.point ?? false,
-            level,
+            visible.points ?? false,
             highlightedPointPosition
           );
           break;
-        case 'block':
-          data &&
+        case 'blocks':
+          plot &&
             highlightedPointPosition &&
             renderObjects(
               ctx,
               ref.current,
-              data.blocks,
-              visible.block ?? false,
-              level,
+              plot.blocks,
+              visible.blocks ?? false,
               highlightedPointPosition
             );
           break;
       }
     });
   }, [highlightedPointPosition]);
-
-  const paint = useCallback<Paint>(
-    (panelMode) => {
-      // TODO move this data fetcher to useFetcher.ts
-      if (panelMode === 'admin') {
-        // data.nodes && addNodes(data.nodes);
-        setData(
-          getAdminViewPositions(dimensions.width, dimensions.height, level, {
-            showClusters: false,
-            showPods: false,
-          })
-        );
-      } else {
-        // data.pods && addPods(data.pods);
-        setData(
-          getDeveloperViewPositions(
-            dimensions.width,
-            dimensions.height,
-            level,
-            { showDeployments: true, showNamespaces: false }
-          )
-        );
-      }
-    },
-    [dimensions, level]
-  );
-
-  isDevMode &&
-    useEffect(() => {
-      console.debug('[usePainter] data: ', data);
-    }, [data]);
 
   return [refMap, level, paint, setLevel, setVisible, highlightedPointPosition];
 };

--- a/src/hooks/usePainter.ts
+++ b/src/hooks/usePainter.ts
@@ -1,10 +1,4 @@
-import React, {
-  RefObject,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { RefObject, useCallback, useEffect, useRef, useState } from 'react';
 import { usePainterEvent } from '~hooks';
 import { report } from '~utils/logger';
 import { renderBlocks, renderGrids, renderPoints } from '~utils/painter';
@@ -96,7 +90,7 @@ export default (): [
             renderBlocks(ctx, ref.current, plot.blocks);
             break;
           case 'base':
-            renderBlocks(ctx, ref.current, plot.blocks, true);
+            // renderBlocks(ctx, ref.current, plot.blocks, true);
             break;
           case 'groups1':
             break;

--- a/src/hooks/usePainterEvent.ts
+++ b/src/hooks/usePainterEvent.ts
@@ -1,8 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import {
-  getCursorPosition,
-  getHighlightedPointPosition,
-} from '~utils/positioner';
+import { getCursorPosition } from '~utils/positioner';
 
 export default (
   dimensions: Record<'width' | 'height', number>,

--- a/src/hooks/usePainterEvent.ts
+++ b/src/hooks/usePainterEvent.ts
@@ -2,16 +2,18 @@ import React, { useEffect, useRef, useState } from 'react';
 import { getCursorPosition } from '~utils/positioner';
 
 export default (
-  dimensions: Record<'width' | 'height', number>,
-  _level: 1 | 2 | 3
+  dimensions: Record<'width' | 'height', number>
 ): [
   React.RefObject<HTMLCanvasElement>,
-  React.Dispatch<1 | 2 | 3>,
-  PointPosition | null
+  PointPosition | null,
+  BlockPositions | null,
+  React.Dispatch<1 | 2 | 3>
 ] => {
-  const [level, setLevel] = useState<1 | 2 | 3>(_level);
+  const [level, setLevel] = useState<1 | 2 | 3>(2);
   const [highlightedPointPosition, setHighlightedPointPosition] =
     useState<PointPosition | null>(null);
+  const [highlightedBlockPositions, setHighlightedBlockPositions] =
+    useState<BlockPositions | null>(null);
 
   const ref = useRef<HTMLCanvasElement>(null);
 
@@ -50,5 +52,5 @@ export default (
       );
   }, [highlightedPointPosition]);
 
-  return [ref, setLevel, highlightedPointPosition];
+  return [ref, highlightedPointPosition, highlightedBlockPositions, setLevel];
 };

--- a/src/hooks/usePainterEvent.ts
+++ b/src/hooks/usePainterEvent.ts
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { report } from '~utils/logger';
 import { getCursorPosition } from '~utils/positioner';
 

--- a/src/hooks/usePainterEvent.ts
+++ b/src/hooks/usePainterEvent.ts
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { report } from '~utils/logger';
 import { getCursorPosition } from '~utils/positioner';
 
 export default (
@@ -46,10 +47,12 @@ export default (
 
   useEffect(() => {
     !!highlightedPointPosition &&
-      console.debug(
-        `[usePainterEvent] level: ${level}, bounded event: `,
-        highlightedPointPosition
-      );
+      report.debug('usePainterEvent', [
+        'level: ',
+        level,
+        'boundedEvent: ',
+        highlightedPointPosition,
+      ]);
   }, [highlightedPointPosition]);
 
   return [ref, highlightedPointPosition, highlightedBlockPositions, setLevel];

--- a/src/hooks/usePainterEvent.ts
+++ b/src/hooks/usePainterEvent.ts
@@ -22,7 +22,7 @@ export default (
     const ctx = ref.current && ref.current.getContext('2d');
     if (ctx === null || ref.current === null) return;
 
-    const handler = (el: MouseEvent) => {
+    const handleMouseMove = (el: MouseEvent) => {
       const x = el.offsetX,
         y = el.offsetY;
 
@@ -36,13 +36,22 @@ export default (
       );
 
       setHighlightedPointPosition(bounded);
+      // setHighlightedBlockPositions(bounded);
     };
 
-    ref.current.addEventListener('mousemove', handler);
-    return () =>
-      ref.current
-        ? ref.current.removeEventListener('mousemove', handler)
-        : undefined;
+    const handleMouseLeave = () => {
+      setHighlightedPointPosition(null);
+      setHighlightedBlockPositions(null);
+    };
+
+    ref.current.addEventListener('mousemove', handleMouseMove);
+    ref.current.addEventListener('mouseleave', handleMouseLeave);
+    return () => {
+      if (ref.current) {
+        ref.current.removeEventListener('mousemove', handleMouseMove);
+        ref.current.removeEventListener('mouseleave', handleMouseLeave);
+      }
+    };
   }, [dimensions, level]);
 
   useEffect(() => {

--- a/src/hooks/usePositioner.ts
+++ b/src/hooks/usePositioner.ts
@@ -1,20 +1,19 @@
-import { useCallback, useEffect, useState } from 'react';
+import { RefObject, useCallback, useEffect, useState } from 'react';
 import { report } from '~utils/logger';
+import { getAdminViewPositions, getDeveloperViewPositions } from '~utils/positioner';
 
 export default (
   ref: RefObject<HTMLCanvasElement>
-): [
-  Dimensions,
-  Positioner.Plot | null,
-  Positioner.Pose,
-  React.Dispatch<1 | 2 | 3>
-] => {
+): [Dimensions, Positioner.Plot | null, Positioner.Pose] => {
   const [plot, setPlot] = useState<Positioner.Plot | null>(null);
+  const [resourceMap, setResourceMap] = useState<Positioner.ResourceMap | null>(
+    null
+  );
+  const [level, setLevel] = useState<1 | 2 | 3 | null>(null);
   const [adminPlot, setAdminPlot] = useState<Positioner.Plot | null>(null);
   const [devPlot, setDevPlot] = useState<Positioner.Plot | null>(null);
 
   const [paused, setPaused] = useState<boolean>(true);
-  const [level, setLevel] = useState<1 | 2 | 3>(2);
   const [dimensions, setDimensions] = useState<Dimensions>({
     width: 0,
     height: 0,
@@ -26,15 +25,41 @@ export default (
     return () => window.removeEventListener('resize', pauser);
   }, []);
 
+  const pose = useCallback<Positioner.Pose>(
+    (resourceMap, level) => {
+      resourceMap.type === 'admin'
+        ? setAdminPlot(
+            getAdminViewPositions(
+              resourceMap,
+              dimensions.width,
+              dimensions.height,
+              level
+            )
+          )
+        : setDevPlot(
+            getDeveloperViewPositions(
+              resourceMap,
+              dimensions.width,
+              dimensions.height,
+              level
+            )
+          );
+      setResourceMap(resourceMap);
+      setLevel(level);
+    },
+    [dimensions]
+  );
+
   useEffect(() => {
     let handler: NodeJS.Timeout | undefined;
     if (paused) {
       if (ref.current === null) return;
       report.log('usePositioner', ['excuted handleResize()']);
       setDimensions({
-        width: ref.current.clientWidth,
-        height: ref.current.clientHeight,
+        width: ref.current.width,
+        height: ref.current.height,
       });
+      !!resourceMap && !!level && pose(resourceMap, level);
       setPaused(false);
     } else {
       handler = undefined;
@@ -45,28 +70,8 @@ export default (
     };
   }, [paused]);
 
-  const pose = useCallback<Positioner.Pose>((resourceMap) => {
-    resourceMap.type === 'admin'
-      ? setAdminPlot(
-          getAdminViewPositions(
-            resourceMap,
-            dimensions.width,
-            dimensions.height,
-            level
-          )
-        )
-      : setDevPlot(
-          getDeveloperViewPositions(
-            resourceMap,
-            dimensions.width,
-            dimensions.height,
-            level
-          )
-        );
-  }, []);
-
   useEffect(() => setPlot(adminPlot), [adminPlot]);
   useEffect(() => setPlot(devPlot), [devPlot]);
 
-  return [dimensions, plot, pose, setLevel];
+  return [dimensions, plot, pose];
 };

--- a/src/hooks/usePositioner.ts
+++ b/src/hooks/usePositioner.ts
@@ -1,17 +1,24 @@
 import React, { RefObject, useCallback, useEffect, useState } from 'react';
-import { getAdminViewPositions, getDeveloperViewPositions } from '~utils/positioner';
+import {
+  getAdminViewPositions,
+  getDeveloperViewPositions,
+} from '~utils/positioner';
 
 export default (
-  _level: 1 | 2 | 3,
   ref: RefObject<HTMLCanvasElement>
-): [Positioner.Dimensions, Positioner.Plot | null, Positioner.Pose] => {
+): [
+  Dimensions,
+  Positioner.Plot | null,
+  Positioner.Pose,
+  React.Dispatch<1 | 2 | 3>
+] => {
   const [plot, setPlot] = useState<Positioner.Plot | null>(null);
   const [adminPlot, setAdminPlot] = useState<Positioner.Plot | null>(null);
   const [devPlot, setDevPlot] = useState<Positioner.Plot | null>(null);
 
   const [paused, setPaused] = useState<boolean>(true);
-  const [level, setLevel] = useState<1 | 2 | 3>(_level);
-  const [dimensions, setDimensions] = useState<Positioner.Dimensions>({
+  const [level, setLevel] = useState<1 | 2 | 3>(2);
+  const [dimensions, setDimensions] = useState<Dimensions>({
     width: 0,
     height: 0,
   });
@@ -64,5 +71,5 @@ export default (
   useEffect(() => setPlot(adminPlot), [adminPlot]);
   useEffect(() => setPlot(devPlot), [devPlot]);
 
-  return [dimensions, plot, pose];
+  return [dimensions, plot, pose, setLevel];
 };

--- a/src/hooks/usePositioner.ts
+++ b/src/hooks/usePositioner.ts
@@ -1,4 +1,4 @@
-import React, { RefObject, useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { report } from '~utils/logger';
 
 export default (

--- a/src/hooks/usePositioner.ts
+++ b/src/hooks/usePositioner.ts
@@ -1,8 +1,5 @@
 import React, { RefObject, useCallback, useEffect, useState } from 'react';
-import {
-  getAdminViewPositions,
-  getDeveloperViewPositions,
-} from '~utils/positioner';
+import { report } from '~utils/logger';
 
 export default (
   ref: RefObject<HTMLCanvasElement>
@@ -33,7 +30,7 @@ export default (
     let handler: NodeJS.Timeout | undefined;
     if (paused) {
       if (ref.current === null) return;
-      console.log('[Positioner] executed handleResize()');
+      report.log('usePositioner', ['excuted handleResize()']);
       setDimensions({
         width: ref.current.clientWidth,
         height: ref.current.clientHeight,
@@ -44,7 +41,7 @@ export default (
     }
     return () => {
       clearTimeout(handler);
-      console.debug('[usePainter] timeout cleared: ', paused);
+      report.log('usePositioner', ['timeout cleared', paused]);
     };
   }, [paused]);
 

--- a/src/hooks/usePositioner.ts
+++ b/src/hooks/usePositioner.ts
@@ -1,0 +1,68 @@
+import React, { RefObject, useCallback, useEffect, useState } from 'react';
+import { getAdminViewPositions, getDeveloperViewPositions } from '~utils/positioner';
+
+export default (
+  _level: 1 | 2 | 3,
+  ref: RefObject<HTMLCanvasElement>
+): [Positioner.Dimensions, Positioner.Plot | null, Positioner.Pose] => {
+  const [plot, setPlot] = useState<Positioner.Plot | null>(null);
+  const [adminPlot, setAdminPlot] = useState<Positioner.Plot | null>(null);
+  const [devPlot, setDevPlot] = useState<Positioner.Plot | null>(null);
+
+  const [paused, setPaused] = useState<boolean>(true);
+  const [level, setLevel] = useState<1 | 2 | 3>(_level);
+  const [dimensions, setDimensions] = useState<Positioner.Dimensions>({
+    width: 0,
+    height: 0,
+  });
+
+  useEffect(() => {
+    const pauser = () => setPaused(true);
+    window.addEventListener('resize', pauser);
+    return () => window.removeEventListener('resize', pauser);
+  }, []);
+
+  useEffect(() => {
+    let handler: NodeJS.Timeout | undefined;
+    if (paused) {
+      if (ref.current === null) return;
+      console.log('[Positioner] executed handleResize()');
+      setDimensions({
+        width: ref.current.clientWidth,
+        height: ref.current.clientHeight,
+      });
+      setPaused(false);
+    } else {
+      handler = undefined;
+    }
+    return () => {
+      clearTimeout(handler);
+      console.debug('[usePainter] timeout cleared: ', paused);
+    };
+  }, [paused]);
+
+  const pose = useCallback<Positioner.Pose>((resourceMap) => {
+    resourceMap.type === 'admin'
+      ? setAdminPlot(
+          getAdminViewPositions(
+            resourceMap,
+            dimensions.width,
+            dimensions.height,
+            level
+          )
+        )
+      : setDevPlot(
+          getDeveloperViewPositions(
+            resourceMap,
+            dimensions.width,
+            dimensions.height,
+            level
+          )
+        );
+  }, []);
+
+  useEffect(() => setPlot(adminPlot), [adminPlot]);
+  useEffect(() => setPlot(devPlot), [devPlot]);
+
+  return [dimensions, plot, pose];
+};

--- a/src/screens/index.tsx
+++ b/src/screens/index.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState } from 'react';
 import { DevelopmentOnlyAlert, UncloudyGraph } from '~components';
 import { useFetcher } from '~hooks';
 import { getFilteringOptions } from '~utils/fetcher';
+import { report } from '~utils/logger';
 
 import {
   BarChartOutlined,
@@ -86,9 +87,7 @@ export default () => {
               style={{ width: '100%' }}
               showTime
               placeholder={['시작일', '종료일']}
-              onChange={(val) => {
-                console.log('val: ', val);
-              }}
+              onChange={(val) => report.log('Screens', ['val: ', val])}
               defaultValue={[
                 moment(new Date()).subtract(15, 'minutes'),
                 moment(new Date()),

--- a/src/screens/index.tsx
+++ b/src/screens/index.tsx
@@ -7,11 +7,7 @@ import { useFetcher } from '~hooks';
 import { getFilteringOptions } from '~utils/fetcher';
 import { report } from '~utils/logger';
 
-import {
-  BarChartOutlined,
-  CodeOutlined,
-  ToolOutlined,
-} from '@ant-design/icons';
+import { BarChartOutlined, CodeOutlined, ToolOutlined } from '@ant-design/icons';
 
 import { MainBlock } from './styles';
 

--- a/src/utils/fetcher.ts
+++ b/src/utils/fetcher.ts
@@ -145,10 +145,8 @@ export const fetchPodMetrics: Fetcher.FetchPodMetrics = async (
 ) => {
   return new Promise((resolve, reject) => {
     try {
-      console.log('data:', data);
       const ret: Record<string, Resource.Pod.Metric[]> = {};
       data.forEach((pod: any) => {
-        console.log(pod);
         // ret[pod.id] =
       });
       resolve(listMap.set('dd', []));

--- a/src/utils/fetcher.ts
+++ b/src/utils/fetcher.ts
@@ -1,3 +1,6 @@
+/**
+ * @module fetcher
+ */
 import { SAMPLE_NODES, SAMPLE_PODS } from '~constants';
 
 import type { Page } from '~models';

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,30 @@
+/**
+ * @module logger
+ */
+type CallbackFn = (moduleName: string, message: any[], color?: string) => void;
+type Report = Record<
+  'debug' | 'info' | 'log' | 'warn' | 'error' | 'assert',
+  CallbackFn
+>;
+
+export const report = [
+  'debug',
+  'info',
+  'log',
+  'warn',
+  'error',
+  'assert',
+].reduce<Report | {}>(
+  (acc, logLevel) => ({
+    ...acc,
+    [logLevel]: ((moduleName, message, color = '#aaa') => {
+      console[logLevel](
+        '%c ' + moduleName + ' %c',
+        'margin-left: -0.5rem; background: ' + color + '; color: white',
+        'background: unset; color: unset',
+        ...message
+      );
+    }) as CallbackFn,
+  }),
+  {}
+) as Report;

--- a/src/utils/painter.ts
+++ b/src/utils/painter.ts
@@ -1,3 +1,6 @@
+/**
+ * @module painter
+ */
 import { DAYS, GRID_SIZE, POS_ZANDIS, SPACING } from '~constants';
 import { report } from '~utils/logger';
 

--- a/src/utils/painter.ts
+++ b/src/utils/painter.ts
@@ -1,4 +1,5 @@
 import { DAYS, GRID_SIZE, POS_ZANDIS, SPACING } from '~constants';
+import { report } from '~utils/logger';
 
 const DX = 2 * (GRID_SIZE + SPACING);
 const DY = GRID_SIZE + SPACING;
@@ -533,7 +534,7 @@ export const paintGrasses: Painter.PaintObject = (
   };
 
   POS_ZANDIS[parseInt('' + Math.random() * 2, 10)].forEach((posZandi) => {
-    console.log('pos: ', posZandi);
+    report.log('Painter', ['pos: ', posZandi]);
     stack.push(paintGrass(ctx, x + posZandi[0], y + posZandi[1], dx, dy, h));
   });
 
@@ -721,7 +722,7 @@ export const renderBlocks: Painter.Render<BlockPositions> = (
   const stackPaintings: (() => void)[] = [];
 
   let paintObject: Painter.PaintObject | null = null;
-  switch (!!positions.data.length ? positions[0].type : null) {
+  report.log('Painter', ['positions: ', positions]);
     case 'pod':
       paintObject = positions.viewType === 'flat' ? paintFlatPod : paintPod;
       break;

--- a/src/utils/painter.ts
+++ b/src/utils/painter.ts
@@ -649,7 +649,7 @@ export const renderLegend = (
   render();
 };
 
-export const renderGrids: Painter.Render<LinePosition> = (
+export const renderGrids: Painter.Render<LinePosition[]> = (
   ctx,
   currentRef,
   positions,
@@ -678,12 +678,11 @@ export const renderGrids: Painter.Render<LinePosition> = (
   render();
 };
 
-export const renderPoints: Painter.Render<PointPosition> = (
+export const renderPoints: Painter.Render<PointPosition[]> = (
   ctx,
   currentRef,
   positions,
   visible,
-  _,
   selectedPosition
 ) => {
   const stackPaintingObject: (() => void)[] = [];
@@ -723,12 +722,11 @@ let prevLevel: 1 | 2 | 3;
 let lastSurface: ImageData | null;
 let ax: number, ay: number;
 
-export const renderObjects: Painter.Render<PointPosition> = (
+export const renderObjects: Painter.Render<BlockPositions> = (
   ctx,
   currentRef,
   positions,
   visible,
-  level,
   selectedPosition
 ) => {
   const stackPaintings: (() => void)[] = [];
@@ -738,21 +736,23 @@ export const renderObjects: Painter.Render<PointPosition> = (
   ctx.scale(1, 1);
 
   let paintObject: Painter.PaintObject | null = null;
-  switch (!!positions.length ? positions[0].type : null) {
+  switch (!!positions.data.length ? positions[0].type : null) {
     case 'pod':
-      paintObject = level === 3 ? paintFlatPod : paintPod;
+      paintObject = positions.viewType === 'flat' ? paintFlatPod : paintPod;
       break;
     case 'node':
-      paintObject = level === 3 ? paintFlatNode : paintNode;
+      paintObject = positions.viewType === 'flat' ? paintFlatNode : paintNode;
       break;
   }
 
-  const { DX, DY } = DELTA[level ?? 2];
+  // const { DX, DY } = DELTA[level ?? 2];
 
-  if (prevLevel !== level) {
-    prevLevel = level ?? 1;
-    lastSurface = null;
-  }
+  // TODO: fix this
+  // if (prevLevel !== level) {
+  //   prevLevel = level ?? 1;
+
+  //   lastSurface = null;
+  // }
 
   if (!!paintObject) {
     if (selectedPosition === null) {
@@ -763,7 +763,7 @@ export const renderObjects: Painter.Render<PointPosition> = (
       ay = selectedPosition.y - 200;
       lastSurface = ctx.getImageData(ax, ay, 400, 400);
 
-      positions.forEach((position) => {
+      positions.data.forEach((position) => {
         const weight =
           (position.row - selectedPosition.row) ** 2 +
           (position.column - selectedPosition.column) ** 2;
@@ -788,7 +788,7 @@ export const renderObjects: Painter.Render<PointPosition> = (
       });
     } else {
       lastSurface = null;
-      positions.forEach((position) => {
+      positions.data.forEach((position) => {
         stackPaintings.push(
           ...paintObject!(
             ctx,
@@ -816,12 +816,11 @@ export const renderObjects: Painter.Render<PointPosition> = (
   render();
 };
 
-export const renderGroups: Painter.Render<GroupPosition> = (
+export const renderGroups: Painter.Render<GroupPositions> = (
   ctx,
   currentRef,
   positions,
   visible,
-  level,
   selectedPosition
 ) => {
   const stackPaintings: (() => void)[] = [];

--- a/src/utils/painter.ts
+++ b/src/utils/painter.ts
@@ -711,7 +711,7 @@ export const renderHighlightedPoints: Painter.Render<PointPosition[]> = (
     stackPaintings.push(...paintPoint(ctx, x, y, 5, 5, 0));
   });
 
-  render(ctx, dimensions, stackPaintings, false, true);
+  render(ctx, dimensions, stackPaintings, true, true);
 };
 
 let lastSurface: ImageData | null;
@@ -726,6 +726,7 @@ export const renderBlocks: Painter.Render<BlockPositions> = (
 
   let paintObject: Painter.PaintObject | null = null;
   report.log('Painter', ['positions: ', positions]);
+  switch (!!positions.data.length ? positions.data[0].type : null) {
     case 'pod':
       paintObject = positions.viewType === 'flat' ? paintFlatPod : paintPod;
       break;
@@ -742,10 +743,10 @@ export const renderBlocks: Painter.Render<BlockPositions> = (
           ctx,
           position.x,
           position.y,
-          positions.dx,
-          positions.dy,
-          position.z ? (positions.dz ?? 35) * position.z : 35,
-          { selected: !!!isBaseCanvas }
+          positions.dx * 0.45,
+          positions.dy * 0.45,
+          position.z ? (positions.dz ?? 1) * position.z : 35,
+          isBaseCanvas ? { selected: true } : undefined
         )
       );
     });
@@ -802,10 +803,13 @@ export const renderGroups: Painter.Render<GroupPositions> = (
 ) => {
   const stackPaintings: (() => void)[] = [];
 
-  console.log('position: ', positions);
   // positions.forEach((position) => {});
 
   // stackPaintings.push(...paintNamespace(ctx, 100, 100, 200, 200));
 
   render(ctx, dimensions, stackPaintings, true, false);
+};
+
+export const clearRendered: Painter.ClearRendered = (ctx, dimensions) => {
+  render(ctx, dimensions, [], true, false);
 };

--- a/src/utils/positioner.ts
+++ b/src/utils/positioner.ts
@@ -1,4 +1,5 @@
 import { DELTA, MAX_COLUMN_OBJECT } from '~constants';
+import { report } from '~utils/logger';
 
 // const plots:
 
@@ -478,10 +479,10 @@ export const getDeveloperViewPositions: Positioner.GetViewPositions<'dev'> = (
       let secondRow =
         (resourceMap.deployments ? resourceMap.deployments.size : 0) >> 1;
 
-      console.log(
-        '[Positioner] deployments: ',
-        resourceMap.deployments ? resourceMap.deployments.size : 0
-      );
+      report.log('Positioner', [
+        'deployments: ',
+        resourceMap.deployments ? resourceMap.deployments.size : 0,
+      ]);
 
       Object.entries(resourceMap.deployments ?? []).map(
         ([deploymentId, deployment], index) => {

--- a/src/utils/positioner.ts
+++ b/src/utils/positioner.ts
@@ -350,7 +350,7 @@ const getBlockPositions: Positioner.GetBlockPositions = (
     viewType: level === 3 ? 'flat' : 'normal',
     dx: canvasValues.DX,
     dy: canvasValues.DY,
-    dz: undefined,
+    dz: 1,
     data: matrixes.map((matrix) => {
       return getPointPosition(
         canvasValues,

--- a/src/utils/positioner.ts
+++ b/src/utils/positioner.ts
@@ -1,3 +1,6 @@
+/**
+ * @module positioner
+ */
 import { DELTA, MAX_COLUMN_OBJECT } from '~constants';
 import { report } from '~utils/logger';
 


### PR DESCRIPTION
본 Pull Request에는 다음과 같은 기능 향상이 있습니다:
- [feat: usePainter를 usePainter, usePositioner 등으로 분리 등 4개 커밋](https://github.com/team-grass-farm/uncloudy-grapher/commit/400501bbb7bd5b05c5c64e0911d170b69e76636f)
  - usePainter를 usePainter, usePositioner 등으로 분리
  - `Plot` 모델 추가
  - @types으로 모든 useHook 내부 모델 이동
  - `main` 캔버스 추가
- [refactor: Painter 내 Render 함수 리팩토링 및 useHook 리턴 값 조정](https://github.com/team-grass-farm/uncloudy-grapher/commit/9b422c9d84447327541d2d6cd79ce4eed743fa03)
- [feat: logger 로깅 모듈 추가](https://github.com/team-grass-farm/uncloudy-grapher/commit/dca2307de307c3675822c3cacc6ac2df4386ab85)
- [style: 모든 useHook 내 `import React` 삭제](https://github.com/team-grass-farm/uncloudy-grapher/commit/b09283ea4c0e2d80ddbf6a30840c30049c66f7cd)
- [style: 모든 모듈 내 JSDoc 어노테이션 추가](https://github.com/team-grass-farm/uncloudy-grapher/commit/7fd6103d1b4c305815960ae27f0689bef478b147)
- [fix: Painter Event 정상화](https://github.com/team-grass-farm/uncloudy-grapher/commit/12849fa4867ea27a18396f64d1aaa5c964c756c0)